### PR TITLE
fix: correct ssh-keys:add warnings

### DIFF
--- a/tasks/ssh-keys.yml
+++ b/tasks/ssh-keys.yml
@@ -13,5 +13,5 @@
   tags:
     - dokku
     - dokku-ssh-keys
-  when: sshcommand_users|skipped or sshcommand_users|failed or sshcommand_users.stdout.find("{{ item.username }}") == -1
+  when: sshcommand_users is skipped or sshcommand_users is failed or sshcommand_users.stdout.find(item.username) == -1
   with_items: "{{ dokku_users }}"


### PR DESCRIPTION
 - ansible is already a Jinja2 expression, remove extra {{}}
 - tests as filters are deprecated "|" changed to  "is"

References:
[When statement is a Jinja2 expression
](https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html#the-when-statement)
[Jinja tests used as filters deprecated
](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.5.html)