### PR TITLE
Fix problem with downgrading herokuish

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -104,6 +104,7 @@
 - name: install dokku packages
   apt:
     name: "{{ item.key }}={{ item.value }}"
+    force: true
   with_dict:
     plugn: "{{ plugn_version }}"
     sshcommand: "{{ sshcommand_version }}"


### PR DESCRIPTION
For some reason, herokuish needs to be at specific version and, this fails, after server update.

Either this has to be merged or herokuish version pinning has to be removed, for it to work. 