### PR TITLE
fix: fix "string field was converted" warnings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,8 +32,8 @@
 - name: dokku plugin:update
   cron:
     name: "dokku plugin:update {{ item.name }}"
-    minute: 0
-    hour: 12
+    minute: "0"
+    hour: "12"
     user: "root"
     job: "/usr/bin/chronic /usr/bin/dokku plugin:update {{ item.name }}"
     cron_file: "dokku-plugin-update-{{ item.name }}"


### PR DESCRIPTION
Ansible `cron` task's `minute` and `hour` fields are string fields (https://docs.ansible.com/ansible/latest/modules/cron_module.html). This commit quotes the values to avoid the following warnings:

```
[WARNING]: The value 0 (type int) in a string field was converted to '0' (type string). If this does not look like what you expect, quote
the entire value to ensure it does not change.

[WARNING]: The value 12 (type int) in a string field was converted to '12' (type string). If this does not look like what you expect, quote
the entire value to ensure it does not change.
```