### PR TITLE
fix: bumps herokuish version

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Supported Platforms
 
 ### herokuish_version
 
-- default: `0.5.2`
+- default: `0.5.3`
 - type: `version`
 - description: The version of herokuish to install
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,6 @@ dokku_skip_key_file: 'false'
 dokku_version: 0.19.5
 dokku_vhost_enable: 'true'
 dokku_web_config: 'false'
-herokuish_version: 0.5.2
+herokuish_version: 0.5.3
 plugn_version: 0.3.2
 sshcommand_version: 0.8.0

--- a/defaults/main.yml.base
+++ b/defaults/main.yml.base
@@ -37,7 +37,7 @@ docker_download_key_sig:
   type: string
 
 herokuish_version:
-  default: 0.5.2
+  default: 0.5.3
   description: The version of herokuish to install
   type: version
 


### PR DESCRIPTION
Installing dokku==0.19.5 on Ubuntu 18.04 automatically installs
herokuish==0.5.3. If we then try to install herokuish==0.5.2 by default, it
will fail since apt refuses to downgrade by default.