### PR TITLE
feat: Adds global domain support to dokku_domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,8 +344,9 @@ Manages domains for a given application
 
 |Parameter|Choices/Defaults|Comments|
 |---------|----------------|--------|
-|app<br /><sup>*required*</sup>||The name of the app|
+|app<br /><sup>*required*</sup>||The name of the app. This is required only if global is set to False.|
 |domains<br /><sup>*required*</sup>||A list of domains|
+|global|*Default:* False|Whether to change the global domains or app-specific domains.|
 |state|*Choices:* <ul><li>enable</li><li>disable</li><li>clear</li><li>**present** (default)</li><li>absent</li></ul>|The state of the application's domains|
 
 #### Example


### PR DESCRIPTION
Adds support for `dokku_domains` to change global domains.

Also, `dokku_domains` used to split the output by newlines. But at lease on `0.19.5`, `dokku --quiet domains:report <app> --domains-app-vhost` actually returns domains on separate lines. So this commit changes `dokku_domains` to split on ` ` instead of `\n` as well.