### PR TITLE
pin versions before installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Supported Platforms
 
 ### sshcommand_version
 
-- default: `0.8.0`
+- default: `0.9.0`
 - type: `version`
 - description: The version of sshcommand to install
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,4 +15,4 @@ dokku_vhost_enable: 'true'
 dokku_web_config: 'false'
 herokuish_version: 0.5.5
 plugn_version: 0.3.2
-sshcommand_version: 0.8.0
+sshcommand_version: 0.9.0

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -101,9 +101,13 @@
   tags:
     - dokku
 
-- name: install dokku packages
-  apt:
-    name: "{{ item.key }}={{ item.value }}"
+- name: pin dokku packages
+  copy:
+    dest: /etc/apt/preferences.d/ansible-hold-{{ item.key }}
+    content: |
+      Package: {{ item.key }}
+      Pin: version {{ item.value }}
+      Pin-Priority: 1001
   with_dict:
     plugn: "{{ plugn_version }}"
     sshcommand: "{{ sshcommand_version }}"
@@ -113,13 +117,9 @@
     - dokku
     - dokku-install
 
-- name: pin dokku packages
-  copy:
-    dest: /etc/apt/preferences.d/ansible-hold-{{ item.key }}
-    content: |
-      Package: {{ item.key }}
-      Pin: version {{ item.value }}
-      Pin-Priority: 1001
+- name: install dokku packages
+  apt:
+    name: "{{ item.key }}={{ item.value }}"
   with_dict:
     plugn: "{{ plugn_version }}"
     sshcommand: "{{ sshcommand_version }}"


### PR DESCRIPTION
Versions of packages were pinned *after* installing, causing issues the
second time the role was run (and packages were found not to correspond
to the versions pinned). Now pinning *before* installing.

Also updated versions to latest available.


Note: Please keep releasing changes via git tags, since ansible galaxy [points to the latest tag](https://galaxy.ansible.com/dokku_bot/ansible_dokku), e.g. `ansible-galaxy install dokku_bot.ansible_dokku` currently installs the release from April 2019.