### PR TITLE
add tests via molecule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ env:
   global:
     - ANSIBLE_ROLE: dokku_bot.ansible_dokku
 
-matrix:
-  - MOLECULE_DISTRO: ubuntu1804
-  - MOLECULE_DISTRO: ubuntu1604
-  - MOLECULE_DISTRO: debian10
-  - MOLECULE_DISTRO: debian9
+  matrix:
+    - MOLECULE_DISTRO: ubuntu1804
+    - MOLECULE_DISTRO: ubuntu1604
+    - MOLECULE_DISTRO: debian10
+    - MOLECULE_DISTRO: debian9
 
 install:
   - pip install molecule docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,10 @@ env:
     - ANSIBLE_ROLE: dokku_bot.ansible_dokku
 
 matrix:
-  include:
-    - name: Ubuntu-18.04
-      env:
-        - DOCKER_IMAGE: marvelnccr/ubuntu-docker-base
-        - DOCKER_IMAGE_VERSION: 2.2
-        - ANSIBLE_USER: ubuntu
-    - name: Ubuntu-16.04
-      env:
-        - docker_image: marvelnccr/ubuntu-docker-base
-        - version: 1.1
-        - ansible_user: ubuntu
+  - MOLECULE_DISTRO: ubuntu1804
+  - MOLECULE_DISTRO: ubuntu1604
+  - MOLECULE_DISTRO: debian10
+  - MOLECULE_DISTRO: debian9
 
 install:
   - pip install molecule docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+---
+# Adapted from
+# - https://github.com/drhelius/travis-ansible-demo/blob/master/.travis.yml
+# - https://github.com/geerlingguy/ansible-role-docker/blob/master/.travis.yml
+language: python
+services:
+  - docker
+
+env:
+  global:
+    - ANSIBLE_ROLE: dokku_bot.ansible_dokku
+
+matrix:
+  include:
+    - name: Ubuntu-18.04
+      env:
+        - DOCKER_IMAGE: marvelnccr/ubuntu-docker-base
+        - DOCKER_IMAGE_VERSION: 2.2
+        - ANSIBLE_USER: ubuntu
+    - name: Ubuntu-16.04
+      env:
+        - docker_image: marvelnccr/ubuntu-docker-base
+        - version: 1.1
+        - ansible_user: ubuntu
+
+install:
+  - pip install molecule docker
+
+before_script:
+  # Use actual Ansible Galaxy role name for the project directory.
+  - cd ../
+  - mv ansible-dokku $ANSIBLE_ROLE
+  - cd $ANSIBLE_ROLE
+
+script:
+  - molecule test
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/example.yml
+++ b/example.yml
@@ -1,35 +1,35 @@
 ---
 examples:
-- name: Installing Dokku
-  example: |
-    ---
-    - hosts: all
-      roles:
-        - dokku
+  - name: Installing Dokku
+    example: |
+      ---
+      - hosts: all
+        roles:
+          - dokku
 
-- name: Installing Plugins
-  example: |
-    ---
-    - hosts: all
-      roles:
-        - dokku
-      vars:
-        dokku_plugins:
-          - name: clone
-            url: https://github.com/crisward/dokku-clone.git
-          - name: postgres
-            url: https://github.com/dokku/dokku-postgres.git
+  - name: Installing Plugins
+    example: |
+      ---
+      - hosts: all
+        roles:
+          - dokku
+        vars:
+          dokku_plugins:
+            - name: clone
+              url: https://github.com/crisward/dokku-clone.git
+            - name: postgres
+              url: https://github.com/dokku/dokku-postgres.git
 
-- name: Deploying a simple word inflector
-  example: |
-    ---
-    - hosts: all
-      tasks:
-        - name: dokku apps:create inflector
-          dokku_app:
-            app: inflector
+  - name: Deploying a simple word inflector
+    example: |
+      ---
+      - hosts: all
+        tasks:
+          - name: dokku apps:create inflector
+            dokku_app:
+              app: inflector
 
-        - name: dokku clone inflector
-          dokku_clone:
-            app: inflector
-            repository: https://github.com/cakephp/inflector.cakephp.org
+          - name: dokku clone inflector
+            dokku_clone:
+              app: inflector
+              repository: https://github.com/cakephp/inflector.cakephp.org

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,4 @@
+---
 - name: start dokku-daemon
   service:
     name: dokku-daemon

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,28 +1,31 @@
 ---
 galaxy_info:
   author: "Jose Diaz-Gonzalez"
-  description: This Ansible role helps install Dokku on Debian/Ubuntu variants. Apart from installing Dokku, it also provides various modules that can be used to interface with dokku from your own Ansible playbooks.
+  description: |
+    This Ansible role helps install Dokku on Debian/Ubuntu variants. Apart
+    from installing Dokku, it also provides various modules that can be
+    used to interface with dokku from your own Ansible playbooks.
   license: MIT License
   version: 2019.04.3
   min_ansible_version: 2.2
   platforms:
     - name: Ubuntu
       versions:
-       - trusty
-       - utopic
-       - vivid
-       - wily
-       - xenial
-       - yakkety
-       - zesty
-       - artful
-       - bionic
+        - trusty
+        - utopic
+        - vivid
+        - wily
+        - xenial
+        - yakkety
+        - zesty
+        - artful
+        - bionic
     - name: Debian
       versions:
-       - wheezy
-       - jessie
-       - stretch
-       - buster
+        - wheezy
+        - jessie
+        - stretch
+        - buster
   galaxy_tags:
     - networking
     - packaging

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,8 +7,10 @@ lint:
     config-file: molecule/default/yamllint.yml
 platforms:
   - name: instance
-    image: "${DOCKER_IMAGE:-marvelnccr/ubuntu-docker-base}:${DOCKER_IMAGE_VERSION:-latest}"
-    command: "${DOCKER_COMMAND:-sleep infinity}"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu1804}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
 provisioner:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,25 @@
+---
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    config-file: molecule/default/yamllint.yml
+platforms:
+  - name: instance
+    image: "${DOCKER_IMAGE:-marvelnccr/ubuntu-docker-base}:${DOCKER_IMAGE_VERSION:-latest}"
+    command: "${DOCKER_COMMAND:-sleep infinity}"
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  playbooks:
+    converge: playbook.yml
+scenario:
+  name: default
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,0 +1,11 @@
+---
+- hosts: all
+  become: true
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes cache_valid_time=600
+      when: ansible_os_family == 'Debian'
+
+  roles:
+    - role: dokku_bot.ansible_dokku

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -6,6 +6,11 @@
     - name: Update apt cache.
       apt: update_cache=yes cache_valid_time=600
       when: ansible_os_family == 'Debian'
+    # see https://jpetazzo.github.io/2013/10/06/policy-rc-d-do-not-start-services-automatically/
+    - name: don't start service when installing packages
+      shell: echo exit 0 > /usr/sbin/policy-rc.d
+      changed_when: false
+      when: ansible_os_family == 'Debian'
 
   roles:
     - role: dokku_bot.ansible_dokku

--- a/molecule/default/yamllint.yml
+++ b/molecule/default/yamllint.yml
@@ -1,0 +1,6 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 120
+    level: warning

--- a/tasks/dokku-daemon.yml
+++ b/tasks/dokku-daemon.yml
@@ -1,10 +1,11 @@
+---
 - block:
   - name: ensure github.com is a known host
     lineinfile:
       dest: /root/.ssh/known_hosts
-      create: yes
+      create: true
       state: present
-      line: "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="
+      line: "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="  # yamllint disable-line rule:line-length
       regexp: "^github\\.com"
     tags:
       - dokku-daemon
@@ -13,7 +14,7 @@
     git:
       repo: https://github.com/dokku/dokku-daemon.git
       dest: /var/lib/dokku-daemon
-      update: no
+      update: false
       version: "{{ dokku_daemon_version }}"
     tags:
       - dokku-daemon

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,3 +1,4 @@
+---
 - name: https apt transport for docker repository
   apt:
     name: apt-transport-https

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - import_tasks: nginx.yml
 
 - import_tasks: install.yml
@@ -9,7 +10,7 @@
 
 - name: dokku plugin:list
   command: dokku plugin
-  changed_when: False
+  changed_when: false
   register: installed_dokku_plugins
   tags:
     - dokku

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -1,3 +1,4 @@
+---
 - block:
   - name: nginx:repository
     apt_repository:

--- a/tasks/ssh-keys.yml
+++ b/tasks/ssh-keys.yml
@@ -1,6 +1,7 @@
+---
 - name: sshcommand list dokku
   command: sshcommand list dokku
-  changed_when: False
+  changed_when: false
   register: sshcommand_users
   tags:
     - dokku
@@ -9,7 +10,7 @@
 
 - name: dokku ssh-keys:add
   shell: echo "{{ item.ssh_key }}" | dokku ssh-keys:add {{ item.username }}
-  no_log: True
+  no_log: true
   tags:
     - dokku
     - dokku-ssh-keys


### PR DESCRIPTION
fixes #26 

This PR
 * adds test configuration via molecule
 * runs tests on Ubuntu 16.04 and 18.04 via Travis CI (as well as Debian 9 & 10)
 * adds yamllint

Furthermore it currently runs the role without any parameters and only tests that the role runs and is idempotent.
One could of course add further tests later on.