### PR TITLE
Adding role to ansible examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ Manage storage for dokku applications
 ---
 - hosts: all
   roles:
-    - dokku
+    - dokku_bot.ansible_dokku
 ```
 
 ### Installing Plugins
@@ -670,7 +670,7 @@ Manage storage for dokku applications
 ---
 - hosts: all
   roles:
-    - dokku
+    - dokku_bot.ansible_dokku
   vars:
     dokku_plugins:
       - name: clone
@@ -684,6 +684,8 @@ Manage storage for dokku applications
 ```yaml
 ---
 - hosts: all
+  roles:
+    - dokku_bot.ansible_dokku
   tasks:
     - name: dokku apps:create inflector
       dokku_app:

--- a/example.yml
+++ b/example.yml
@@ -5,14 +5,14 @@ examples:
       ---
       - hosts: all
         roles:
-          - dokku
+          - dokku_bot.ansible_dokku
 
   - name: Installing Plugins
     example: |
       ---
       - hosts: all
         roles:
-          - dokku
+          - dokku_bot.ansible_dokku
         vars:
           dokku_plugins:
             - name: clone
@@ -24,6 +24,8 @@ examples:
     example: |
       ---
       - hosts: all
+        roles:
+          - dokku_bot.ansible_dokku
         tasks:
           - name: dokku apps:create inflector
             dokku_app:


### PR DESCRIPTION
Thanks for the amazing work on this project! I'm new to ansible, but I believe the examples provided are missing the `role` in some cases and the role should be the Galaxy identifier to make it easier to install + use. 