### PR TITLE
Removing unused force_list from dokku_app

### DIFF
--- a/library/dokku_app.py
+++ b/library/dokku_app.py
@@ -37,13 +37,6 @@ EXAMPLES = '''
     state: absent
 '''
 
-
-def force_list(l):
-    if isinstance(l, list):
-        return l
-    return list(l)
-
-
 def dokku_apps_exists(app):
     exists = False
     error = None


### PR DESCRIPTION
Looks like this was just copied over from another file which actually uses this.

