### PR TITLE
Apps and Config enhancements

### DIFF
--- a/library/dokku_app.py
+++ b/library/dokku_app.py
@@ -22,6 +22,7 @@ options:
     default: present
     choices: [ "present", "absent" ]
     aliases: []
+modified by: Elliott Castillo
 author: Jose Diaz-Gonzalez
 requirements: [ ]
 '''
@@ -31,11 +32,18 @@ EXAMPLES = '''
   dokku_app:
     app: hello-world
 
-- name: Delete that repo
+- name: Delete the app
   dokku_app:
     app: hello-world
     state: absent
 '''
+
+
+def force_list(l):
+    if isinstance(l, list):
+        return l
+    return list(l)
+
 
 def dokku_apps_exists(app):
     exists = False
@@ -95,6 +103,62 @@ def dokku_app_absent(data=None):
     return (is_error, has_changed, meta)
 
 
+def dokku_app_rename(data):
+    is_error = True
+    has_changed = False
+    meta = {'present': False}
+
+    exists, error = dokku_apps_exists(data['app'])
+    rename_exists, error2 = dokku_apps_exists(data['rename'])
+    if rename_exists:
+        meta['error'] = "The name {0} is already taken by an existing app. Cannot continue.".format(data['rename'])
+    elif exists:
+        is_error = False
+        meta['present'] = True
+
+        command = 'dokku apps:rename {0} {1}'.format(data['app'], data['rename'])
+        try:
+            subprocess.check_call(command, shell=True)
+            is_error = False
+            has_changed = True
+            meta['present'] = True
+        except subprocess.CalledProcessError as e:
+            meta['error'] = str(e)
+    else:
+        meta['error'] = "The app named {0} does not exist. Cannot rename it".format(data['app'])
+
+    return (is_error, has_changed, meta)
+
+
+def dokku_app_clone(data):
+    is_error = True
+    has_changed = False
+    meta = {'present': False}
+
+    exists, error = dokku_apps_exists(data['app'])
+    clone_name_exists, error2 = dokku_apps_exists(data['clone'])
+    if not clone_name_exists: # if the app that should be used to clone does not exist error out
+        meta['error'] = "The app {0} does not currently exist. Cannot clone.".format(data['clone'])
+    elif exists: # if the app you want to create already exists do no-op
+        is_error = False
+        meta['present'] = True
+        return (is_error, has_changed, meta)
+    else:
+        is_error = False
+        meta['present'] = True
+
+        command = 'dokku apps:clone {0} {1}'.format(data['clone'], data['app'])
+        try:
+            subprocess.check_call(command, shell=True)
+            is_error = False
+            has_changed = True
+            meta['present'] = True
+        except subprocess.CalledProcessError as e:
+            meta['error'] = str(e)
+
+    return (is_error, has_changed, meta)
+
+
 def main():
     fields = {
         'app': {
@@ -110,6 +174,17 @@ def main():
             ],
             'type': 'str',
         },
+        'rename': {
+            'required': False,
+            'type': 'str',
+            'default': '',
+        },
+        'clone': {
+            'required': False,
+            'type': 'str',
+            'default': '',
+        },
+
     }
     choice_map = {
         'present': dokku_app_present,
@@ -120,12 +195,39 @@ def main():
         argument_spec=fields,
         supports_check_mode=False
     )
-    is_error, has_changed, result = choice_map.get(
-        module.params['state'])(module.params)
 
-    if is_error:
-        module.fail_json(msg=result['error'], meta=result)
-    module.exit_json(changed=has_changed, meta=result)
+    is_error = False
+    
+    has_changed = False
+    has_changed1 = False
+    has_changed2 = False
+    has_changed3 = False
+
+    result = {}
+    result1 = {}
+    result2 = {}
+    result3 = {}
+
+    if (not module.params['rename'] == '' or not module.params['clone'] == '') and module.params['state'] == 'absent':
+        module.fail_json(msg="cannot delete the app and (rename or clone it) at the same time", meta="yoyoma")
+    elif not module.params['rename'] == '' and not module.params['clone'] == '':
+        module.fail_json(msg="cannot have both rename and clone enabled at the same time", meta="yoyo")
+    elif not module.params['rename'] == '': # app rename function
+        is_error, has_changed2, result2 = dokku_app_rename(module.params)
+        if is_error:
+            module.fail_json(msg=result2['error'], meta=result2)
+    elif not module.params['clone'] == '': # app clone function
+        is_error, has_changed3, result3 = dokku_app_clone(module.params)
+        if is_error:
+            module.fail_json(msg=result3['error'], meta=result3)
+    else: # app create or app destroy functions
+        is_error, has_changed1, result1 = choice_map.get(
+        module.params['state'])(module.params)
+        if is_error:
+            module.fail_json(msg=result['error'], meta=result)
+    
+    has_changed = True if has_changed1 or has_changed2 or has_changed3 else False
+    module.exit_json(changed=has_changed, result_create_delete=result1, result_rename=result2, result_clone=result3)
 
 
 if __name__ == '__main__':

--- a/library/dokku_config.py
+++ b/library/dokku_config.py
@@ -5,6 +5,7 @@ from ansible.module_utils.basic import AnsibleModule
 import json
 import pipes
 import subprocess
+import logging
 
 try:
     basestring
@@ -19,9 +20,15 @@ short_description: Manage environment variables for a given dokku application
 options:
   app:
     description:
-      - The name of the app
+      - The name of the app... if global envar, use: --global
     required: True
     default: null
+    aliases: []
+  restart:
+    description:
+      - True or False for restarting the app to restart after applying the envar
+    required: False
+    default: False
     aliases: []
   config:
     description:
@@ -29,7 +36,14 @@ options:
     required: True
     default: {}
     aliases: []
+  unset:
+    description:
+      - A list of envar KEYS to unset. If you put the KEY in CONFIG and in UNSET it applies the key and then unsets it resulting in a "changed" state
+    required: False
+    default: []
+    aliases: []
 author: Jose Diaz-Gonzalez
+modified by: Elliott Castillo
 requirements: [ ]
 '''
 
@@ -37,9 +51,11 @@ EXAMPLES = '''
 - name: set KEY=VALUE
   dokku_config:
     app: hello-world
+    restart: "True"
     config:
       KEY: VALUE_1
       KEY_2: VALUE_2
+    unset: ["KEY_3", "KEY_4", "KEY_5"]
 '''
 
 
@@ -69,15 +85,19 @@ def subprocess_check_output(command, split='\n'):
 
 
 def dokku_config(app):
-    command = 'dokku config:export --format json {0}'.format(app)
-    output, error = subprocess_check_output(command, split=None)
+    if app == '--global':
+        command = 'dokku config:export --format json --global'
+        output, error = subprocess_check_output(command, split=None)
+    else:
+        command = 'dokku config:export --format json {0}'.format(app)
+        output, error = subprocess_check_output(command, split=None)
 
     if error is None:
         try:
             output = json.loads(output)
         except ValueError as e:
             error = str(e)
-
+    # error = output
     return output, error
 
 
@@ -85,39 +105,92 @@ def dokku_config_set(data):
     is_error = True
     has_changed = False
     meta = {'present': False}
-
+    meta = {'error1': None}
+    options = []
+    
     values = []
     invalid_values = []
     existing, error = dokku_config(data['app'])
     for key, value in data['config'].items():
+        # if it's not a valid string or unicode string, add to invalid, skip
         if not isinstance(value, basestring):
             invalid_values.append(key)
             continue
-
+        # if the value of the envar is unchanged, skip
         if value == existing.get(key, None):
             continue
         values.append('{0}={1}'.format(key, pipes.quote(value)))
 
     if invalid_values:
         template = 'All values must be keys, found invalid types for {0}'
-        meta['error'] = template.format(', '.join(invalid_values))
+        meta['error1'] = template.format(', '.join(invalid_values))
         return (is_error, has_changed, meta)
 
     if len(values) == 0:
         is_error = False
         has_changed = False
         return (is_error, has_changed, meta)
+    
+    if not data['restart']:
+        options.append('--no-restart') 
+    
+    # you can further modify this to add other params such as "encoded" or other options in future dokku versions
 
-    command = 'dokku config:set {0} {1}'.format(data['app'], ' '.join(values))
+    if data['app'] == '--global':
+        command = 'dokku config:set {1} --global {0}'.format(' '.join(values), ' '.join(options))
+    else:
+        command = 'dokku config:set {2} {0} {1}'.format(data['app'], ' '.join(values), ' '.join(options))
+    
+    # config:set command execution
     try:
         subprocess.check_call(command, shell=True)
         is_error = False
         has_changed = True
     except subprocess.CalledProcessError as e:
-        meta['error'] = str(e)
+        meta['error1'] = str(e)
 
     return (is_error, has_changed, meta)
 
+def dokku_config_unset(data):
+    unset_values = []
+    is_error = True
+    has_changed = False
+    meta = {'present': False}
+    meta.update({'error2': None})
+    options = []
+    
+    # get existing keys
+    existing, error = dokku_config(data['app'])
+    # config:unset command execution
+    dl = force_list(data['unset'])
+    meta.update({'unset': data['unset']})
+    # if the delete list is not empty
+    if dl:
+        # construct the list of values that are to be unset
+        for ki in dl:
+            if ki in existing.keys():
+                unset_values.append(ki)
+        unset_values = force_list(unset_values)
+        # if there are values to unset
+        if unset_values:
+            if data['app'] == '--global':
+                unset_command = 'dokku config:unset --global {0}'.format(' '.join(unset_values))
+            else:
+                unset_command = 'dokku config:unset {2} {0} {1}'.format(data['app'], ' '.join(unset_values), ' '.join(options))
+    
+            try:
+                subprocess.check_call(unset_command, shell=True)
+                is_error = False
+                has_changed = True
+            except subprocess.CalledProcessError as e:
+                meta['error2'] = str(e)
+        else:
+            is_error = False
+            has_changed = False
+    else:
+        is_error = False
+
+    return (is_error, has_changed, meta)
 
 def main():
     fields = {
@@ -125,10 +198,20 @@ def main():
             'required': True,
             'type': 'str',
         },
+        'restart': {
+            'required': False,
+            'type': 'bool',
+            'default': False
+        },
         'config': {
             'required': True,
             'type': 'dict',
-            'no_log': True
+            'no_log': True,
+        },
+        'unset': {
+            'required': False,
+            'type': 'list',
+            'default': []
         },
     }
 
@@ -136,12 +219,25 @@ def main():
         argument_spec=fields,
         supports_check_mode=False
     )
-    is_error, has_changed, result = dokku_config_set(
-        module.params)
+
+    is_error2 = False
+    has_changed2 = False
+    result2 = {}
+    
+    # Do the config:set operation
+    is_error1, has_changed1, result1 = dokku_config_set(module.params)
+
+    # Do the config:unset operation
+    if not module.params['unset'] == []:
+        is_error2, has_changed2, result2 = dokku_config_unset(module.params)
+    
+    # check the error indicator for each operation
+    is_error = True if is_error1 or is_error2 else False
+    has_changed = True if has_changed1 or has_changed2 else False
 
     if is_error:
-        module.fail_json(msg=result['error'], meta=result)
-    module.exit_json(changed=has_changed, meta=result)
+        module.fail_json(msg=result1['error1'], config_set_operation=result1, config_unset_operation=result2)
+    module.exit_json(changed=has_changed, config_set_operation=result1, config_unset_operation=result2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
added the capability to rename and clone apps
added the ability to add env vars to the global app and to unset and toggle restart when setting env vars for all apps. if a key is both in the config dict AND in the unset list, then env var will first be added and then deleted. all of these functions will respect the restart instruction.
tried to make error handling as descriptive as possible so that errors can carry through from the various functions instead of from a single function. Have used it several times now and it works well with dokku v 0.19.x