### PR TITLE
Fix getting plugin list for installed_dokku_plugins variable

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
   when: dokku_users is defined
 
 - name: dokku plugin:list
-  command: dokku plugin
+  command: dokku plugin:list
   changed_when: false
   register: installed_dokku_plugins
   tags:


### PR DESCRIPTION
Previously used command `dokku plugin` is not working now. So installing already installed plugin [fails](https://pastebin.com/RHZTCvc7).
I replaced `dokku plugin` to `dokku plugin:list` and now plugin installation checking is working [normally](https://pastebin.com/CF5izzTB).

As I see in documentation repo (https://github.com/dokku/dokku/commit/30bf228dc971fae6de4899b8cd5e40c30bb45a1f) `dokku plugin` deprecated about 3 years ago.