### PR TITLE
Specify rules for plugin:install failure

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,11 @@
     - dokku-plugins
   when: dokku_plugins is defined and installed_dokku_plugins.stdout.find(item.name) == -1
   with_items: "{{ dokku_plugins }}"
+  register: dokku_plugin_install
+  failed_when:
+    - "'fatal: destination path' not in dokku_plugin_install.stderr"
+  changed_when:
+    - "'fatal: destination path' not in dokku_plugin_install.stderr"
 
 - name: dokku plugin:update
   cron:


### PR DESCRIPTION
Closes https://github.com/dokku/ansible-dokku/issues/59.

If plugins are already in place this will 1) not fail when `git` trys to clone them in and 2) not show as changed in the Ansible task list because we know that a `git clone` error with this specific error message means nothing changed.

I have manually tested this a number of times and am pretty happy with it.