### PR TITLE
Install plugin dependencies too

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,3 +43,11 @@
   tags:
     - dokku
     - dokku-plugins
+
+- name: dokku:plugin install-dependencies
+  command: dokku plugin:install-dependencies
+  tags:
+    - dokku
+    - dokku-plugins
+    - molecule-idempotence-notest
+  when: dokku_plugins is defined


### PR DESCRIPTION
Once plugins are installed, plugin dependencies should also be installed so that application deployments that rely on those plugins and their dependencies can be used immediately.