### PR TITLE
Fix vhost file value

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -86,3 +86,12 @@
   tags:
     - dokku
     - dokku-install
+
+- name: write vhost
+  when: dokku_vhost_enable | bool
+  copy:
+    content: "{{ dokku_hostname }}"
+    dest: /home/dokku/VHOST
+  tags:
+    - dokku
+    - dokku-install


### PR DESCRIPTION
Dokku takes base host for applications from `VHOST` file. This file contains hostname of operation system by default (`ubuntu` in my case). I fixed the value of `VHOST` with `dokku_hostname` variable.

May be related to #19 

P. S. Tested with Ubuntu 18.04