### PR TITLE
fix parsing of dokku global-cert:report

### DIFF
--- a/library/dokku_global_cert.py
+++ b/library/dokku_global_cert.py
@@ -97,7 +97,7 @@ def dokku_global_cert(data):
         "subject",
         "verified",
     ]
-    RE_PREFIX = re.compile("^global cert-")
+    RE_PREFIX = re.compile("^global-cert-")
     for line in output:
         if ":" not in line:
             continue


### PR DESCRIPTION
fixes #72 

Example output:

    dokku --quiet global-cert:report
           Global cert dir:     /var/lib/dokku/config/global-cert
           Global cert enabled: false
           Global cert expires at:
           Global cert hostnames:
           Global cert issuer:
           Global cert starts at:
           Global cert subject:
           Global cert verified:

The parsing then tries to extract e.g. the 'enabled', 'expires', ...
keys by some searching & replacing.
In particular, all spaces are replaced by dashes, so should be the
prefix to be removed.