### PR TITLE
add test for dokku_global_cert

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: all
+- name: Converge
+  hosts: all
   become: true
 
   pre_tasks:
@@ -9,3 +10,7 @@
 
   roles:
     - role: dokku_bot.ansible_dokku
+      vars:
+        dokku_plugins:
+          - name: global-cert
+            url: https://github.com/josegonzalez/dokku-global-cert

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -23,7 +23,3 @@ provisioner:
   name: ansible
   playbooks:
     converge: converge.yml
-scenario:
-  name: default
-verifier:
-  name: testinfra

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,12 @@
+---
+- name: Verify
+  hosts: all
+  become: true
+
+  tasks:
+    - name: Bare include (free-form)
+      include_vars: ../../defaults/main.yml
+
+    - name: Check that dokku_global_cert module can parse output
+      dokku_global_cert:
+        state: absent


### PR DESCRIPTION
So far, CI is only testing that the role can be installed (with default options).

That's fine, but the role includes a number of features that aren't tested by this approach.
Here, I'm adding a test for #72 as the 'verify' stage (which currently fails, and should be resolved after #73 is merged).

This approach can be used going forward to test any other feature that isn't part of the regular role setup.