### PR TITLE
bump dokku version to 0.21.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Supported Platforms
 
 - geerlingguy.docker ansible role
 - nginxinc.nginx ansible role
-- Dokku version 0.19.11 (for library usage)
+- Dokku version 0.21.1 (for library usage)
 
 ## Role Variables
 
@@ -113,7 +113,7 @@ Supported Platforms
 
 ### dokku_version
 
-- default: `0.19.11`
+- default: `0.21.1`
 - type: `version`
 - description: The version of Dokku to install
 
@@ -131,19 +131,19 @@ Supported Platforms
 
 ### herokuish_version
 
-- default: `0.5.5`
+- default: `0.5.14`
 - type: `version`
 - description: The version of herokuish to install
 
 ### plugn_version
 
-- default: `0.3.2`
+- default: `0.5.0`
 - type: `version`
 - description: The version of plugn to install
 
 ### sshcommand_version
 
-- default: `0.9.0`
+- default: `0.11.0`
 - type: `version`
 - description: The version of sshcommand to install
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,9 +6,9 @@ dokku_key_file: /root/.ssh/id_rsa.pub
 dokku_manage_nginx: true
 dokku_plugins: {}
 dokku_skip_key_file: 'false'
-dokku_version: 0.19.11
+dokku_version: 0.21.1
 dokku_vhost_enable: 'true'
 dokku_web_config: 'false'
-herokuish_version: 0.5.5
-plugn_version: 0.3.2
-sshcommand_version: 0.9.0
+herokuish_version: 0.5.14
+plugn_version: 0.5.0
+sshcommand_version: 0.11.0

--- a/defaults/main.yml.base
+++ b/defaults/main.yml.base
@@ -1,6 +1,6 @@
 ---
 dokku_version:
-  default: 0.19.11
+  default: 0.21.1
   description: The version of Dokku to install
   type: version
 
@@ -19,17 +19,17 @@ dokku_daemon_version:
   type: string
 
 herokuish_version:
-  default: 0.5.5
+  default: 0.5.14
   description: The version of herokuish to install
   type: version
 
 sshcommand_version:
-  default: 0.9.0
+  default: 0.11.0
   description: The version of sshcommand to install
   type: version
 
 plugn_version:
-  default: 0.3.2
+  default: 0.5.0
   description: The version of plugn to install
   type: version
 


### PR DESCRIPTION
Bump default versions of dokku, herokuish, plugn and sshcommand to latest releases.