### PR TITLE
update dokku-daemon dependency

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
 skip_list:
+- '106' # Role name does not match ``^[a-z][a-z0-9_]+$`` pattern
 - '204' # Lines should be no longer than 160 chars.
 - '306' # Shells that use pipes should set the pipefail option.

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
 
 install:
   - pip install -r requirements.txt
+  - ansible --version
 
 before_script:
   # Use actual Ansible Galaxy role name for the project directory.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Supported Platforms
 
 ### dokku_daemon_version
 
-- default: `c36a2460f9f7737bb4fb6621f6961773933a1409`
+- default: `0.0.2`
 - type: `string`
 - description: Version of dokku-daemon to install
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Supported Platforms
 
 ### dokku_daemon_version
 
-- default: `f3b7b0ab1b6368d49e569de03af28e497ce0a0c9`
+- default: `c36a2460f9f7737bb4fb6621f6961773933a1409`
 - type: `string`
 - description: Version of dokku-daemon to install
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 dokku_daemon_install: true
-dokku_daemon_version: c36a2460f9f7737bb4fb6621f6961773933a1409
+dokku_daemon_version: 0.0.2
 dokku_hostname: dokku.me
 dokku_key_file: /root/.ssh/id_rsa.pub
 dokku_manage_nginx: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 dokku_daemon_install: true
-dokku_daemon_version: f3b7b0ab1b6368d49e569de03af28e497ce0a0c9
+dokku_daemon_version: c36a2460f9f7737bb4fb6621f6961773933a1409
 dokku_hostname: dokku.me
 dokku_key_file: /root/.ssh/id_rsa.pub
 dokku_manage_nginx: true

--- a/defaults/main.yml.base
+++ b/defaults/main.yml.base
@@ -14,7 +14,7 @@ dokku_daemon_install:
   description: Whether to install the dokku-daemon
   type: boolean
 dokku_daemon_version:
-  default: f3b7b0ab1b6368d49e569de03af28e497ce0a0c9
+  default: c36a2460f9f7737bb4fb6621f6961773933a1409
   description: Version of dokku-daemon to install
   type: string
 

--- a/defaults/main.yml.base
+++ b/defaults/main.yml.base
@@ -14,7 +14,7 @@ dokku_daemon_install:
   description: Whether to install the dokku-daemon
   type: boolean
 dokku_daemon_version:
-  default: c36a2460f9f7737bb4fb6621f6961773933a1409
+  default: 0.0.2
   description: Version of dokku-daemon to install
   type: string
 

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -12,11 +12,13 @@
         state: absent
 
     - name: Get dokku_hostname  # noqa 301
-      command: dokku domains
+      command: dokku domains:report --global
       register: dokku_domains
 
     - name: Check that dokku_hostname is set correctly
       assert:
         that:
           - "'test.domain' in dokku_domains.stdout"
-        msg: "hostname 'test.domain' not found in output of 'dokku domains'"
+        msg: |
+          hostname 'test.domain' not found in output of 'dokku domains':
+          {{ dokku_domains.stdout }}

--- a/tasks/dokku-daemon.yml
+++ b/tasks/dokku-daemon.yml
@@ -7,6 +7,7 @@
       state: present
       line: "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="  # yamllint disable-line rule:line-length
       regexp: "^github\\.com"
+      mode: 0644
     tags:
       - dokku-daemon
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -66,6 +66,7 @@
       Package: {{ item.key }}
       Pin: version {{ item.value }}
       Pin-Priority: 1001
+    mode: preserve
   with_dict:
     plugn: "{{ plugn_version }}"
     sshcommand: "{{ sshcommand_version }}"
@@ -92,6 +93,7 @@
   copy:
     content: "{{ dokku_hostname }}"
     dest: /home/dokku/VHOST
+    mode: preserve
   tags:
     - dokku
     - dokku-install

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -18,6 +18,7 @@
       state: directory
       owner: root
       group: root
+      mode: 0755
     with_items:
       - sites-enabled
       - sites-available


### PR DESCRIPTION
fix #77

The dokku-daemon version used by the role was from Jan 2017 and
overlooked in recent updates of dependencies.

Also, fix `hostname` test (`dokku domains` command deprecated).