### PR TITLE
Add flags option for dokku_service_link

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ Links and unlinks a given service to an application
 |Parameter|Choices/Defaults|Comments|
 |---------|----------------|--------|
 |app<br /><sup>*required*</sup>||The name of the app|
+|flags|*Default:* {}|The flags for the service|
 |name<br /><sup>*required*</sup>||The name of the service|
 |service<br /><sup>*required*</sup>||The type of service to link|
 |state|*Choices:* <ul><li>**present** (default)</li><li>absent</li></ul>|The state of the service link|
@@ -604,6 +605,8 @@ Links and unlinks a given service to an application
     app: hello-world
     name: default
     service: redis
+    flags:
+      alias: BLUE_DATABASE
 
 - name: redis:unlink default hello-world
   dokku_service_link:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ansible-lint
 black
 docker==4.2.0
 flake8
-molecule==3.0.2
+molecule==3.0.3
 pyyaml
 testinfra==5.0.0
 yamllint


### PR DESCRIPTION
This PR contains changes to support `--link-flags` when using `dokku_service_link`. This might be a bit naive approach as I'm not sure if you can change these flags by calling the command again or you have to `unlink` first and then call `link` again.

Also, I am not sure how to test the functionality properly. I would appreciate some help with that.

Closes #68