### PR TITLE
update ssh key when user is updated

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -14,3 +14,7 @@
       - name: global-cert
         url: https://github.com/josegonzalez/dokku-global-cert
       dokku_hostname: test.domain
+      dokku_users:
+      - name: Giuseppe Verdi
+        username: gverdi
+        ssh_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC+G029J1r06FCB0rvavqdHcFZickiGcSH5a4un/DT5Gt4xVThM66WhkoEBY/F5yXTH49r5D2ky5G1aACPQeewfkeseV8A0y07fmLPyPjtKz/bOX7904GqFGNV3q+SBHkiYMk0JhUbOJM1C6Iyq03c4rmU4EVTI2hX/uZg3R65ezI/H94BHJyt/U/Nrip1FFhV9EoltAhLNhvMO8cxET+xqJUorjIiHA0JIUZQ02GTH2uwH2Qycv93vA0G7TJPTwHO1WJFpKr+2SWVW4auvA8zBx6epWuRxQO45nD3cQwpjCOt/YbVxt7Q2PJDVy+1OB3p1Q/NkuvDR5ht056quxwOVLYYSllSmEbDgml+5LOIsEqRw+OAbv1Y8FQq+Gr+J53RTmqkPQZLgyhYLWJ/sQKB2rMOntIVfpEzPI6ikFIG63BxwxPnRb9zr1VKOxWMKWEqtpE0YLy3JoDn8oi0oSDfCITqsf9pa5NDnjWPuxyKz6FwHXvrCmiG4tsRyLD7AOp8= verdi@doremi"

--- a/tasks/ssh-key.yml
+++ b/tasks/ssh-key.yml
@@ -1,0 +1,12 @@
+- name: store sha256 hash of ssh key for user {{ username }}
+  shell: ssh-keygen -lf <(echo "{{ ssh_key }}") | awk '{print $2}'
+  no_log: true
+  args:
+    executable: /bin/bash
+  changed_when: false
+  register: sha256
+
+- name: dokku ssh-keys:add for user {{ username }}
+  shell: echo "{{ ssh_key }}" | dokku ssh-keys:add {{ username }}
+  no_log: true
+  when: force_add or ssh_key_list.find(sha256.stdout) == -1

--- a/tasks/ssh-keys.yml
+++ b/tasks/ssh-keys.yml
@@ -7,11 +7,14 @@
   - dokku-ssh-keys
   ignore_errors: true
 
-- name: dokku ssh-keys:add
-  shell: echo "{{ item.ssh_key }}" | dokku ssh-keys:add {{ item.username }}
-  no_log: true
+- name: add ssh key for user {{ item.username }}
+  include_tasks: ssh-key.yml
   tags:
   - dokku
   - dokku-ssh-keys
-  when: sshcommand_users is skipped or sshcommand_users is failed or sshcommand_users.stdout.find(item.username) == -1
   with_items: "{{ dokku_users }}"
+  vars:
+    username: "{{ item.username }}"
+    ssh_key: "{{ item.ssh_key }}"
+    ssh_key_list: "{{ sshcommand_users.stdout }}"
+    force_add: "{{ sshcommand_users is skipped or sshcommand_users is failed or sshcommand_users.stdout.find(item.username) == -1 }}"


### PR DESCRIPTION
fixes #83

Updating the `ssh_key` field of a user did not result in the ssh key of that user being updated (since existing users were skipped).

This commit adds a check on the SSH key and will update oudated keys.