### PR TITLE
dokku_ports: set port instead of add port

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ Manage ports for a given dokku application
 #### Example
 
 ```yaml
-- name: proxy:ports-add hello-world http:80:80
+- name: proxy:ports-set hello-world http:80:80
   dokku_ports:
     app: hello-world
     mappings:

--- a/library/dokku_ports.py
+++ b/library/dokku_ports.py
@@ -35,7 +35,7 @@ requirements: [ ]
 """
 
 EXAMPLES = """
-- name: proxy:ports-add hello-world http:80:80
+- name: proxy:ports-set hello-world http:80:80
   dokku_ports:
     app: hello-world
     mappings:
@@ -163,7 +163,7 @@ def dokku_proxy_ports_present(data):
         meta["present"] = True
         return (is_error, has_changed, meta)
 
-    command = "dokku --quiet proxy:ports-add {0} {1}".format(
+    command = "dokku --quiet proxy:ports-set {0} {1}".format(
         data["app"], " ".join(to_add)
     )
     try:


### PR DESCRIPTION
fix #90 

Since new apps are created with a default port mapping (for http/https)
already, adding new port mappings using `proxy:ports-add` has no effect
on actual behavior since dokku will simply continue to use the port
mappings defined initially.

In order to be of practical use, `dokku_ports` should use
`proxy:ports-set` instead of `proxy:ports-add`.