### PR TITLE
fix permissions for apt version pinning files

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -65,7 +65,7 @@
       Package: {{ item.key }}
       Pin: version {{ item.value }}
       Pin-Priority: 1001
-    mode: preserve
+    mode: 0644
   with_dict:
     plugn: "{{ plugn_version }}"
     sshcommand: "{{ sshcommand_version }}"


### PR DESCRIPTION
Permissions of the pin files were left unspecified, resulting in 0600 in
my test case, which is not recommended (and caused e.g. the `check_apt`
binary of icinga to fail when not run as root).