### PR TITLE
fix package pinning

### DIFF
--- a/tasks/install-pin.yml
+++ b/tasks/install-pin.yml
@@ -1,4 +1,4 @@
-- name: pin dokku packages where requested
+- name: pin {{ item.key }} package
   copy:
     dest: /etc/apt/preferences.d/ansible-hold-{{ item.key }}
     content: |
@@ -8,7 +8,15 @@
     mode: 0644
   when: item.value
 
-- name: remove pins from 'unpinned' dokku packages
+# note: this is necessary since the apt module with "state: present"
+# does *not* check whether the package version agrees with the
+# pinned version.
+- name: install pinned {{ item.key }} package
+  apt:
+    name: "{{ item.key }}={{ item.value }}"
+  when: item.value
+
+- name: remove pin from {{ item.key }} package
   file:
     path: /etc/apt/preferences.d/ansible-hold-{{ item.key }}
     state: absent

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -58,6 +58,8 @@
   tags:
   - dokku
 
+# this can be removed in July 2021
+# (package pinning deprecated).
 - name: package pinning
   include_tasks: install-pin.yml
   with_dict:


### PR DESCRIPTION
After PR 97, package pinning was not reflected in the packages actually
installed since the ansible `apt` module with `state: present` does not
ensure that packages comply with a pinned version - it only makes sure
the package is present.

In order to install the pinned version, the version needs to be passed
to the `apt` module explicitly.
This was the case prior to PR 97 and is reintroduced here.