### PR TITLE
package pinning: fix installation order

### DIFF
--- a/tasks/install-pin.yml
+++ b/tasks/install-pin.yml
@@ -1,3 +1,9 @@
+- name: remove pin from {{ item.key }} package
+  file:
+    path: /etc/apt/preferences.d/ansible-hold-{{ item.key }}
+    state: absent
+  when: not item.value
+
 - name: pin {{ item.key }} package
   copy:
     dest: /etc/apt/preferences.d/ansible-hold-{{ item.key }}
@@ -7,17 +13,3 @@
       Pin-Priority: 1001
     mode: 0644
   when: item.value
-
-# note: this is necessary since the apt module with "state: present"
-# does *not* check whether the package version agrees with the
-# pinned version.
-- name: install pinned {{ item.key }} package
-  apt:
-    name: "{{ item.key }}={{ item.value }}"
-  when: item.value
-
-- name: remove pin from {{ item.key }} package
-  file:
-    path: /etc/apt/preferences.d/ansible-hold-{{ item.key }}
-    state: absent
-  when: not item.value

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -71,6 +71,20 @@
   - dokku
   - dokku-install
 
+# note: this is necessary since the apt module with "state: present" (below)
+# does *not* check whether the package version agrees with the pinned version.
+# Cannot be done in the pinning loop since all packages need to be unpinned
+# (or you can get version conflicts).
+- name: install pinned {{ item.key }} package
+  apt:
+    name: "{{ item.key }}={{ item.value }}"
+  with_dict:
+    plugn: "{{ plugn_version }}"
+    sshcommand: "{{ sshcommand_version }}"
+    herokuish: "{{ herokuish_version }}"
+    dokku: "{{ dokku_version }}"
+  when: item.value
+
 - name: install dokku packages
   apt:
     name:


### PR DESCRIPTION
The current setup could still lead to issues when the roles was
unpinning packages in an existing installation, since it would try
installing the unpinned versions before all previous pins were removed
(which could lead to version conflicts due to cross-dependencies between
dokku packages).

This commit isolates the pinning from the installation.