### PR TITLE
Add dokku_letsencrypt library method

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,12 @@
 
 
 Contributions to the the Dokku open source project are highly welcome!
-For general hints see the project-wide [cotributing guide](https://github.com/dokku/.github/blob/master/CONTRIBUTING.md).
+For general hints see the project-wide [contributing guide](https://github.com/dokku/.github/blob/master/CONTRIBUTING.md).
 
 ## Codebase overview
 
- * The role's directory layout follows [standard ansible practises](https://galaxy.ansible.com/docs/contributing/creating_role.html#roles).
- * Besides the yaml-based ansible instructions, the role includes several new ansible *modules* in the `library/` folder (e.g. `dokku_app`).
+ * The role's directory layout follows [standard Ansible practices](https://galaxy.ansible.com/docs/contributing/creating_role.html#roles).
+ * Besides the yaml-based ansible instructions, the role includes several new Ansible *modules* in the `library/` folder (e.g. `dokku_app`).
  * The `README.md` of this repository is auto-generated: do *not* edit it directly.  
    In order to update it, run `make generate`.
 

--- a/README.md
+++ b/README.md
@@ -474,6 +474,34 @@ Manages global ssl configuration.
     state: absent
 ```
 
+### dokku_letsencrypt
+
+Enable or disable the letsencrypt plugin for a dokku app
+
+#### Requirements
+
+- the `dokku-letsencrypt` plugin
+
+#### Parameters
+
+|Parameter|Choices/Defaults|Comments|
+|---------|----------------|--------|
+|app<br /><sup>*required*</sup>||The name of the app|
+|state|*Choices:* <ul><li>**present** (default)</li><li>absent</li></ul>|The state of the letsencrypt plugin|
+
+#### Example
+
+```yaml
+- name: Enable the letsencrypt plugin
+  dokku_letsencrypt:
+    app: hello-world
+
+- name: Disable the letsencrypt plugin
+  dokku_letsencrypt:
+    app: hello-world
+    state: absent
+```
+
 ### dokku_ports
 
 Manage ports for a given dokku application

--- a/library/dokku_letsencrypt.py
+++ b/library/dokku_letsencrypt.py
@@ -1,0 +1,149 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# from ansible.module_utils.basic import *
+from ansible.module_utils.basic import AnsibleModule
+import subprocess
+
+DOCUMENTATION = """
+---
+module: dokku_letsencrypt
+short_description: Enable or disable the letsencrypt plugin for a dokku app
+options:
+  app:
+    description:
+      - The name of the app
+    required: True
+    default: null
+    aliases: []
+  state:
+    description:
+      - The state of the letsencrypt plugin
+    required: False
+    default: present
+    choices: [ "present", "absent" ]
+    aliases: []
+author: Gavin Ballard
+requirements:
+  - the `dokku-letsencrypt` plugin
+"""
+
+EXAMPLES = """
+- name: Enable the letsencrypt plugin
+  dokku_letsencrypt:
+    app: hello-world
+
+- name: Disable the letsencrypt plugin
+  dokku_letsencrypt:
+    app: hello-world
+    state: absent
+"""
+
+
+def force_list(var):
+    if isinstance(var, list):
+        return var
+    return list(var)
+
+
+def subprocess_check_output(command, split="\n"):
+    error = None
+    output = []
+    try:
+        output = subprocess.check_output(command, shell=True)
+        if isinstance(output, bytes):
+            output = output.decode("utf-8")
+        output = str(output).rstrip("\n")
+        if split is None:
+            return output, error
+
+        output = output.split(split)
+        output = force_list(filter(None, output))
+        output = [o.strip() for o in output]
+    except subprocess.CalledProcessError as e:
+        error = str(e)
+    return output, error
+
+
+def dokku_letsencrypt_enabled(data):
+    command = "dokku --quiet letsencrypt:list | awk '{{print $1}}'"
+    response, error = subprocess_check_output(command.format(data["app"]))
+
+    if error:
+        return None, error
+
+    return data["app"] in response, error
+
+
+def dokku_letsencrypt_present(data):
+    is_error = True
+    has_changed = False
+    meta = {"present": False}
+
+    enabled, error = dokku_letsencrypt_enabled(data)
+    if enabled:
+        is_error = False
+        meta["present"] = True
+        return (is_error, has_changed, meta)
+
+    command = "dokku --quiet letsencrypt:enable {0}".format(data["app"])
+    try:
+        subprocess.check_call(command, shell=True)
+        is_error = False
+        has_changed = True
+        meta["present"] = True
+    except subprocess.CalledProcessError as e:
+        meta["error"] = str(e)
+
+    return (is_error, has_changed, meta)
+
+
+def dokku_letsencrypt_absent(data=None):
+    is_error = True
+    has_changed = False
+    meta = {"present": True}
+
+    enabled, error = dokku_letsencrypt_enabled(data)
+    if enabled is False:
+        is_error = False
+        meta["present"] = False
+        return (is_error, has_changed, meta)
+
+    command = "dokku --quiet letsencrypt:disable {0}".format(data["app"])
+    try:
+        subprocess.check_call(command, shell=True)
+        is_error = False
+        has_changed = True
+        meta["present"] = False
+    except subprocess.CalledProcessError as e:
+        meta["error"] = str(e)
+
+    return (is_error, has_changed, meta)
+
+
+def main():
+    fields = {
+        "app": {"required": True, "type": "str"},
+        "state": {
+            "required": False,
+            "default": "present",
+            "choices": ["present", "absent"],
+            "type": "str",
+        },
+    }
+    choice_map = {
+        "present": dokku_letsencrypt_present,
+        "absent": dokku_letsencrypt_absent,
+    }
+
+    module = AnsibleModule(argument_spec=fields, supports_check_mode=False)
+    is_error, has_changed, result = choice_map.get(module.params["state"])(
+        module.params
+    )
+
+    if is_error:
+        module.fail_json(msg=result["error"], meta=result)
+    module.exit_json(changed=has_changed, meta=result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #9, by adding a simple library method that can be used to enable or disable Let's Encrypt on a specific application.

This took a slightly different approach to the existing draft implementation in #49.