### PR TITLE
should not filter out existing mapping when using ports-set

### DIFF
--- a/library/dokku_ports.py
+++ b/library/dokku_ports.py
@@ -150,21 +150,15 @@ def dokku_proxy_ports_present(data):
         meta["error"] = "missing required arguments: mappings"
         return (is_error, has_changed, meta)
 
-    existing, error = dokku_proxy_port_mappings(data)
-    if error:
-        meta["error"] = error
-        return (is_error, has_changed, meta)
+    to_set = [pipes.quote(m) for m in data["mappings"]]
 
-    to_add = [m for m in data["mappings"] if m not in existing]
-    to_add = [pipes.quote(m) for m in to_add]
-
-    if len(to_add) == 0:
+    if len(to_set) == 0:
         is_error = False
         meta["present"] = True
         return (is_error, has_changed, meta)
 
     command = "dokku --quiet proxy:ports-set {0} {1}".format(
-        data["app"], " ".join(to_add)
+        data["app"], " ".join(to_set)
     )
     try:
         subprocess.check_call(command, shell=True)


### PR DESCRIPTION
With the implementation of PR #91 a bug was introduced, where it would remove existing port-mappings.

### Example role
```yaml
- name: configure ports
  dokku_ports:
    app: example-app
    mappings:
      - http:80:9000
      - https:443:9000
    state: present
```

### Issue description
In the case that port 80 was already mapped in dokku, the check on existing mappings would result in the removal from the mapping on dokku, as only port 443 would be included in the `ports-set` command.
On a next run the exact opposite would occur, port 443 would be removed and port 80 would be added. 

This PR simply removes the check on existing mappings