### PR TITLE
fix: update copyright statement

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (C) 2014 Jeff Lindsay
+Copyright (C) 2019 Jose Diaz-Gonzalez
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
fix #114

The copyright statement in the source code license had been copied from
dokku and did not reflect the reality of this repository.