### PR TITLE
fix: drop support for outdated operating systems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
     strategy:
       matrix:
-        distro: [ubuntu1604, ubuntu1804, ubuntu2004, debian9, debian10]
+        distro: [ubuntu1804, ubuntu2004, debian10, debian11]
       fail-fast: false
 
     steps:

--- a/README.md
+++ b/README.md
@@ -25,8 +25,13 @@ Minimum Ansible Version: 2.2
 
 Supported Platforms
 
+- Ubuntu: xenial
+- Ubuntu: yakkety
+- Ubuntu: zesty
+- Ubuntu: artful
 - Ubuntu: bionic
 - Ubuntu: focal
+- Debian: stretch
 - Debian: buster
 - Debian: bullseye
 

--- a/README.md
+++ b/README.md
@@ -25,20 +25,10 @@ Minimum Ansible Version: 2.2
 
 Supported Platforms
 
-- Ubuntu: trusty
-- Ubuntu: utopic
-- Ubuntu: vivid
-- Ubuntu: wily
-- Ubuntu: xenial
-- Ubuntu: yakkety
-- Ubuntu: zesty
-- Ubuntu: artful
 - Ubuntu: bionic
 - Ubuntu: focal
-- Debian: wheezy
-- Debian: jessie
-- Debian: stretch
 - Debian: buster
+- Debian: bullseye
 
 ## Dependencies
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,10 +10,15 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
+    - xenial
+    - yakkety
+    - zesty
+    - artful
     - bionic
     - focal
   - name: Debian
     versions:
+    - stretch
     - buster
     - bullseye
   galaxy_tags:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,22 +10,12 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
-    - trusty
-    - utopic
-    - vivid
-    - wily
-    - xenial
-    - yakkety
-    - zesty
-    - artful
     - bionic
     - focal
   - name: Debian
     versions:
-    - wheezy
-    - jessie
-    - stretch
     - buster
+    - bullseye
   galaxy_tags:
   - networking
   - packaging

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,7 @@
     name:
     - moreutils    # for plugin updates
     - rsync        # for dokku git:sync
+    - cron         # missing on debian11
   tags:
   - dokku-plugins
 


### PR DESCRIPTION
On Ubuntu 16.04 the nginxinc.nginx roles fails with

  The repository 'https://nginx.org/packages/mainline/ubuntu xenial Release' does not have a Release file.

Seems like it's time to drop support; same for Debian 9.

Fixes #123 since all checks will be working again.