### PR TITLE
chore: drop nginxinc.nginx role

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -29,4 +29,3 @@ galaxy_info:
   - system
 dependencies:
 - role: geerlingguy.docker
-- role: nginxinc.nginx


### PR DESCRIPTION
nginxinc.nginx dropped support for Ubuntu 16.04 and Debian 9.
However, installing dokku should install nginx automatically, i.e. the
role was unnecessary in the first place.