### PR TITLE
Fix the check for the `app` key of the data object in `dokku_network_property`

### DIFF
--- a/library/dokku_network_property.py
+++ b/library/dokku_network_property.py
@@ -69,7 +69,7 @@ def dokku_network_property_set(data):
     has_changed = False
     meta = {"present": False}
 
-    if data["global"] and "app" in data:
+    if data["global"] and data["app"]:
         is_error = True
         meta["error"] = 'When "global" is set to true, "app" must not be provided.'
         return (is_error, has_changed, meta)


### PR DESCRIPTION
This PR fixes the following bug from occuring
```json
{
  "changed": false,
  "module_stderr": "Shared connection to [blank] closed.\r\n",
  "module_stdout": "{'global': True, 'property': 'initial-network', 'value': 'app-internal', 'app': None}\r\n\r\n{\"meta\": {\"present\": false, \"error\": \"When \\\"global\\\" is set to true, \\\"app\\\" must not be provided.\"}, \"failed\": true, \"msg\": \"When \\\"global\\\" is set to true, \\\"app\\\" must not be provided.\", \"invocation\": {\"module_args\": {\"global\": true, \"property\": \"initial-network\", \"value\": \"app-internal\", \"app\": null}}}\r\n",
  "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
  "rc": 1
}
```
When using the following task description:
```yaml
- name: Setting a global network property
  dokku_network_property:
    global: true
    property: initial-network
    value: app-internal
```