### PR TITLE
fix(dokku_storage): continue iteration when storage correctly mounted

### DIFF
--- a/library/dokku_storage.py
+++ b/library/dokku_storage.py
@@ -220,7 +220,7 @@ def dokku_storage_absent(data):
             return (is_error, has_changed, meta)
         elif not exists:
             is_error = False
-            return (is_error, has_changed, meta)
+            continue
 
         command = "dokku --quiet storage:unmount {0} {1}:{2}".format(
             data["app"], data["host_dir"], data["container_dir"]

--- a/library/dokku_storage.py
+++ b/library/dokku_storage.py
@@ -266,7 +266,7 @@ def dokku_storage_present(data):
             return (is_error, has_changed, meta)
         elif exists:
             is_error = False
-            return (is_error, has_changed, meta)
+            continue
 
         command = "dokku --quiet storage:mount {0} {1}:{2}".format(
             data["app"], data["host_dir"], data["container_dir"]


### PR DESCRIPTION
On the first existing element of the `mount` list under a `dokku_storage` the iteration stops because of `return`.

```
- name: "Mount persistent storage"
  dokku_storage:
    app: example-app
    mounts:
      - /var/lib/dokku/data/storage/mount1:/app/mount1
      - /var/lib/dokku/data/storage/mount2/app/mount2
      - /var/lib/dokku/data/storage/mount3:/app/mount3
```

In the above case if `/var/lib/dokku/data/storage/mount2/app/mount2` already mounted then `/var/lib/dokku/data/storage/mount1:/app/mount1` would be added but not `/var/lib/dokku/data/storage/mount3:/app/mount3`

