### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,7 +1,17 @@
 # use `# noqa xxx` at the end of a line, to ignore a particular error
-# or add to the warn_list, to ignore for the whole project
+# or add to the skip_list/warn_list, to ignore for the whole project
+skip_list:
+- name
+- fqcn-builtins
+- yaml[line-length]
+- risky-shell-pipe
+
 warn_list:
-  - '106' # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern
-  - '204' # Lines should be no longer than 160 chars.
-  - '208' # File permissions unset or incorrect
-  - '306' # Shells that use pipes should set the pipefail option.
+- role-name
+
+# it appears that for errors related to missing roles/modules
+# (internal-error, syntax-check), the "# noqa" task/line-based approach of
+# skipping rules has no effect, which forces us to skip the entire file.
+exclude_paths:
+- molecule/default/converge.yml
+- molecule/default/verify.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,28 +3,28 @@
 repos:
 
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v1.5.0
+  rev: v2.4.0
   hooks:
   - id: pretty-format-yaml
     args: [--autofix, --indent, "2", --preserve-quotes]
 
 - repo: https://github.com/adrienverge/yamllint
-  rev: v1.25.0
+  rev: v1.28.0
   hooks:
   - id: yamllint
 
 - repo: https://github.com/psf/black
-  rev: 20.8b1
+  rev: 22.8.0
   hooks:
   - id: black
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.4
+  rev: 5.0.4
   hooks:
   - id: flake8
 
 - repo: https://github.com/ansible/ansible-lint
-  rev: v4.3.5
+  rev: v6.5.2
   hooks:
   - id: ansible-lint
     files: \.(yaml|yml)$

--- a/bin/generate
+++ b/bin/generate
@@ -149,7 +149,7 @@ def add_requirements(text, meta, defaults):
     dependencies = []
     if len(meta["dependencies"]) > 0:
         dependencies = [
-            "- {0} ansible role".format(dependency)
+            "- {0} ansible role".format(dependency["role"])
             for dependency in meta["dependencies"]
         ]
     dependencies.append("- Dokku (for library usage)")

--- a/library/dokku_storage.py
+++ b/library/dokku_storage.py
@@ -94,7 +94,7 @@ def get_gid(group):
 
 
 def get_state(b_path):
-    """ Find out current state """
+    """Find out current state"""
 
     if os.path.lexists(b_path):
         if os.path.islink(b_path):

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
     from installing Dokku, it also provides various modules that can be
     used to interface with dokku from your own Ansible playbooks.
   license: MIT License
-  min_ansible_version: 2.2
+  min_ansible_version: '2.2'
   # See e.g. https://galaxy.ansible.com/api/v1/platforms/?name=Ubuntu
   platforms:
   - name: Ubuntu
@@ -26,5 +26,5 @@ galaxy_info:
   - packaging
   - system
 dependencies:
-- geerlingguy.docker
-- nginxinc.nginx
+- role: geerlingguy.docker
+- role: nginxinc.nginx

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,7 +8,7 @@
     when: ansible_os_family == 'Debian'
 
   roles:
-  - role: dokku_bot.ansible_dokku
+  - role: dokku_bot.ansible_dokku  # noqa
     vars:
       dokku_plugins:
       - name: global-cert

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,7 +7,7 @@
 - name: dokku repo
   apt_repository:
     filename: dokku
-    repo: 'deb https://packagecloud.io/dokku/dokku/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} main'
+    repo: 'deb https://packagecloud.io/dokku/dokku/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main'
 
     state: present
   tags:


### PR DESCRIPTION
`black` and `ansible-lint` hooks were failing, likely due to dependencies that were not locked down properly.