### PR TITLE
Fix dokku_acl_app and dokku_acl_service ansible libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - uses: pre-commit/action@v2.0.0
 
   readme:
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Install requirements
       run: pip install -r requirements.txt
@@ -60,10 +60,10 @@ jobs:
       with:
         path: ${{ env.galaxy-name }}
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
 
     - name: Upgrade pip
       run: |
@@ -82,8 +82,9 @@ jobs:
     # See https://github.com/geerlingguy/raspberry-pi-dramble/issues/166
     - name: Force GitHub Actions' docker daemon to use vfs.
       run: |
+        sudo apt install -y jq
         sudo systemctl stop docker
-        echo '{"cgroup-parent":"/actions_job","storage-driver":"vfs"}' | sudo tee /etc/docker/daemon.json
+        echo '{ "exec-opts": ["native.cgroupdriver=cgroupfs"], "cgroup-parent": "/actions_job", "storage-driver":"vfs"}' | sudo tee /etc/docker/daemon.json
         sudo systemctl start docker
 
     - name: Run molecule

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   hooks:
   - id: black
 
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 5.0.4
   hooks:
   - id: flake8

--- a/library/dokku_acl_app.py
+++ b/library/dokku_acl_app.py
@@ -55,7 +55,7 @@ def dokku_acl_app_set(data):
 
     # get users for app
     command = "dokku acl:list {0}".format(data["app"])
-    output, error = subprocess_check_output(command)
+    output, error = subprocess_check_output(command, redirect_stderr=True)
 
     if error is not None:
         meta["error"] = error

--- a/library/dokku_acl_service.py
+++ b/library/dokku_acl_service.py
@@ -62,12 +62,13 @@ def dokku_acl_service_set(data):
     has_changed = False
 
     # get users for service
-    command = "dokku --quiet acl:list {0}".format(data["service"])
-    output, error = subprocess_check_output(command)
+    command = "dokku --quiet acl:list-service {0} {1}".format(data["type"], data["service"])
+    output, error = subprocess_check_output(command, redirect_stderr=True)
 
     if error is not None:
         meta["error"] = error
         return (is_error, has_changed, meta)
+
 
     users = set(output)
 
@@ -76,7 +77,7 @@ def dokku_acl_service_set(data):
             if user not in users:
                 continue
 
-            command = "dokku --quiet acl:remove {0} {1} {2}".format(
+            command = "dokku --quiet acl:remove-service {0} {1} {2}".format(
                 data["type"], data["service"], user
             )
             output, error = subprocess_check_output(command)
@@ -89,10 +90,10 @@ def dokku_acl_service_set(data):
             if user in users:
                 continue
 
-            command = "dokku --quiet acl:add {0} {1} {2}".format(
+            command = "dokku --quiet acl:add-service {0} {1} {2}".format(
                 data["type"], data["service"], user
             )
-            output, error = subprocess_check_output(command)
+            output, error = subprocess_check_output(command, redirect_stderr=True)
             has_changed = True
             if error is not None:
                 meta["error"] = error

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,4 +1,6 @@
 galaxy_info:
+  role_name: ansible_dokku
+  namespace: dokku_bot
   author: "Jose Diaz-Gonzalez"
   description: |
     This Ansible role helps install Dokku on Debian/Ubuntu variants. Apart

--- a/module_utils/dokku_utils.py
+++ b/module_utils/dokku_utils.py
@@ -9,18 +9,20 @@ def force_list(var):
         return var
     return list(var)
 
-
-def subprocess_check_output(command, split="\n"):
+# Add an option to redirect stderr to stdout, because some dokku commands output to stderr
+def subprocess_check_output(command, split="\n", redirect_stderr=False):
     error = None
     output = []
     try:
-        output = subprocess.check_output(command, shell=True)
+        if redirect_stderr:
+            output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
+        else:
+            output = subprocess.check_output(command, shell=True)
         if isinstance(output, bytes):
             output = output.decode("utf-8")
         output = str(output).rstrip("\n")
         if split is None:
             return output, error
-
         output = output.split(split)
         output = force_list(filter(None, output))
         output = [o.strip() for o in output]

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,7 +9,9 @@ platforms:
   image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu1804}-ansible:latest"
   command: ${MOLECULE_DOCKER_COMMAND:-""}
   volumes:
-  - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - /var/lib/containerd
+  cgroupns_mode: host
   privileged: true
   pre_build_image: true
 provisioner:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # for running tests
-molecule[docker]~=3.3.0
-docker~=4.4.4
-ansible~=4.6.0
+molecule[docker]~=4.0.4
+docker~=6.0.1
+ansible~=7.1.0
 # for development
 pre-commit
 # for README generation


### PR DESCRIPTION
This PR provides a couple of minor fixes:

1. the dokku commands that list ACL information return the data on stderr, however the plugin was trying to read it from stdout. Added a `redirect_stderr` option on `subprocess_check_output` (which defaults to False, to avoid breaking usage anywhere else), and then modified dokku_acl_app and dokku_acl_service to set that to `True`
2. The dokku_acl_service module wasn't using the right `dokku acl:...` commands to list/add/remove

This change is pretty small, I've tested this locally to confirm it works. Let me know if anything else is needed!