### PR TITLE
Fix dokku_acl_app and dokku_acl_service ansible libraries

### DIFF
--- a/library/dokku_acl_app.py
+++ b/library/dokku_acl_app.py
@@ -55,7 +55,7 @@ def dokku_acl_app_set(data):
 
     # get users for app
     command = "dokku acl:list {0}".format(data["app"])
-    output, error = subprocess_check_output(command)
+    output, error = subprocess_check_output(command, redirect_stderr=True)
 
     if error is not None:
         meta["error"] = error

--- a/library/dokku_acl_service.py
+++ b/library/dokku_acl_service.py
@@ -62,13 +62,14 @@ def dokku_acl_service_set(data):
     has_changed = False
 
     # get users for service
-    command = "dokku --quiet acl:list-service {0} {1}".format(data["type"], data["service"])
+    command = "dokku --quiet acl:list-service {0} {1}".format(
+        data["type"], data["service"]
+    )
     output, error = subprocess_check_output(command, redirect_stderr=True)
 
     if error is not None:
         meta["error"] = error
         return (is_error, has_changed, meta)
-
 
     users = set(output)
 

--- a/library/dokku_acl_service.py
+++ b/library/dokku_acl_service.py
@@ -62,12 +62,13 @@ def dokku_acl_service_set(data):
     has_changed = False
 
     # get users for service
-    command = "dokku --quiet acl:list {0}".format(data["service"])
-    output, error = subprocess_check_output(command)
+    command = "dokku --quiet acl:list-service {0} {1}".format(data["type"], data["service"])
+    output, error = subprocess_check_output(command, redirect_stderr=True)
 
     if error is not None:
         meta["error"] = error
         return (is_error, has_changed, meta)
+
 
     users = set(output)
 
@@ -76,7 +77,7 @@ def dokku_acl_service_set(data):
             if user not in users:
                 continue
 
-            command = "dokku --quiet acl:remove {0} {1} {2}".format(
+            command = "dokku --quiet acl:remove-service {0} {1} {2}".format(
                 data["type"], data["service"], user
             )
             output, error = subprocess_check_output(command)
@@ -89,10 +90,10 @@ def dokku_acl_service_set(data):
             if user in users:
                 continue
 
-            command = "dokku --quiet acl:add {0} {1} {2}".format(
+            command = "dokku --quiet acl:add-service {0} {1} {2}".format(
                 data["type"], data["service"], user
             )
-            output, error = subprocess_check_output(command)
+            output, error = subprocess_check_output(command, redirect_stderr=True)
             has_changed = True
             if error is not None:
                 meta["error"] = error

--- a/module_utils/dokku_utils.py
+++ b/module_utils/dokku_utils.py
@@ -9,13 +9,16 @@ def force_list(var):
         return var
     return list(var)
 
+
 # Add an option to redirect stderr to stdout, because some dokku commands output to stderr
 def subprocess_check_output(command, split="\n", redirect_stderr=False):
     error = None
     output = []
     try:
         if redirect_stderr:
-            output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
+            output = subprocess.check_output(
+                command, shell=True, stderr=subprocess.STDOUT
+            )
         else:
             output = subprocess.check_output(command, shell=True)
         if isinstance(output, bytes):

--- a/module_utils/dokku_utils.py
+++ b/module_utils/dokku_utils.py
@@ -9,18 +9,20 @@ def force_list(var):
         return var
     return list(var)
 
-
-def subprocess_check_output(command, split="\n"):
+# Add an option to redirect stderr to stdout, because some dokku commands output to stderr
+def subprocess_check_output(command, split="\n", redirect_stderr=False):
     error = None
     output = []
     try:
-        output = subprocess.check_output(command, shell=True)
+        if redirect_stderr:
+            output = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT)
+        else:
+            output = subprocess.check_output(command, shell=True)
         if isinstance(output, bytes):
             output = output.decode("utf-8")
         output = str(output).rstrip("\n")
         if split is None:
             return output, error
-
         output = output.split(split)
         output = force_list(filter(None, output))
         output = [o.strip() for o in output]


### PR DESCRIPTION
This PR provides a couple of minor fixes:

1. the dokku commands that list ACL information return the data on stderr, however the plugin was trying to read it from stdout. Added a `redirect_stderr` option on `subprocess_check_output` (which defaults to False, to avoid breaking usage anywhere else), and then modified dokku_acl_app and dokku_acl_service to set that to `True`
2. The dokku_acl_service module wasn't using the right `dokku acl:...` commands to list/add/remove

This change is pretty small, I've tested this locally to confirm it works. Let me know if anything else is needed!