### PR TITLE
fix: remove DOKKU_LETSENCRYPT_EMAIL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1124,8 +1124,6 @@ Manage storage for dokku applications
       dokku_config:
         app: *appname
         config:
-          # specify a email for dokku-letsencrypt
-          DOKKU_LETSENCRYPT_EMAIL: email@example.com
           # specify port so `domains` can setup the port mapping properly
           PORT: "5000"
     - name: git clone
@@ -1138,6 +1136,9 @@ Manage storage for dokku applications
         app: *appname
         domains:
           - example.com
+    - name: add letsencrypt
+      dokku_letsencrypt:
+        app: *appname
 ```
 
 ## Contributing

--- a/example.yml
+++ b/example.yml
@@ -76,3 +76,6 @@ examples:
             app: *appname
             domains:
               - example.com
+        - name: add letsencrypt
+          dokku_letsencrypt:
+            app: *appname

--- a/example.yml
+++ b/example.yml
@@ -64,8 +64,6 @@ examples:
           dokku_config:
             app: *appname
             config:
-              # specify a email for dokku-letsencrypt
-              DOKKU_LETSENCRYPT_EMAIL: email@example.com
               # specify port so `domains` can setup the port mapping properly
               PORT: "5000"
         - name: git clone


### PR DESCRIPTION
this isn't a valid option anymore. There's not a replacement for this using the standard ansible dokku stuff
you need to run a shell script.

https://github.com/dokku/ansible-dokku/issues/52#issuecomment-1732331395
