### PR TITLE
fix: pin requests package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # for running tests
 molecule~=24.2.1
 molecule-plugins[docker]~=23.5.3
+requests==2.30.0
 docker~=7.0.0
 ansible~=9.5.1
 # for development


### PR DESCRIPTION
A new version of the `requests` library breaks molecule's docker plugin, which causes continuous integration tests to fail [1].

[1] https://github.com/ansible-community/molecule-plugins/issues/256