### PR TITLE
Add Ubuntu 24 to tested/supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,7 @@ jobs:
 
     strategy:
       matrix:
-        # Remove debian10 until dependency gets re-added.
-        # https://github.com/dokku/docker-container-healthchecker/issues/129
-        distro: [ubuntu2004, ubuntu2204, debian11, debian12]
+        distro: [ubuntu2004, ubuntu2204, ubuntu2404, debian11, debian12]
       fail-fast: false
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   - id: flake8
 
 - repo: https://github.com/ansible/ansible-lint
-  rev: v24.2.0
+  rev: v24.9.2
   hooks:
   - id: ansible-lint
     files: \.(yaml|yml)$

--- a/README.md
+++ b/README.md
@@ -25,14 +25,10 @@ Minimum Ansible Version: 2.2
 
 Supported Platforms
 
-- Ubuntu: xenial
-- Ubuntu: yakkety
-- Ubuntu: zesty
-- Ubuntu: artful
-- Ubuntu: bionic
+- Ubuntu: numbat
+- Ubuntu: jammy
 - Ubuntu: focal
-- Debian: stretch
-- Debian: buster
+- Debian: bookworm
 - Debian: bullseye
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Minimum Ansible Version: 2.2
 
 Supported Platforms
 
-- Ubuntu: numbat
+- Ubuntu: noble
 - Ubuntu: jammy
 - Ubuntu: focal
 - Debian: bookworm

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,16 +12,12 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
-    - xenial
-    - yakkety
-    - zesty
-    - artful
-    - bionic
+    - numbat
+    - jammy
     - focal
   - name: Debian
     versions:
-    - stretch
-    - buster
+    - bookworm
     - bullseye
   galaxy_tags:
   - networking

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
-    - numbat
+    - noble
     - jammy
     - focal
   - name: Debian


### PR DESCRIPTION
Add Ubuntu 24 `noble` to tested and documented-supported versions.

Remove EOL OS versions from readme.

- https://endoflife.date/ubuntu
- https://endoflife.date/debian

Ensure versions meet lint requirements of
https://github.com/ansible/ansible-lint/blob/main/src/ansiblelint/schemas/meta.json#L1102
Requires update of plugin version
https://github.com/ansible/ansible-lint/releases
