### PR TITLE
Add `dokku_buildpacks` library

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,33 @@ Manage the builder configuration for a given dokku application
     value: herokuish
 ```
 
+### dokku_buildpacks
+
+Manage buildpack settings for a given dokku application
+
+#### Parameters
+
+|Parameter|Choices/Defaults|Comments|
+|---------|----------------|--------|
+|app<br /><sup>*required*</sup>||The name of the app|
+|buildpacks<br /><sup>*required*</sup>||A list of buildpacks to set on the app|
+
+#### Example
+
+```yaml
+- name: buildpacks:add hello-world […], buildpacks:add hello-world […]
+  dokku_buildpacks:
+    app: hello-world
+    buildpacks:
+      - https://github.com/heroku/heroku-buildpack-ruby.git
+      - https://github.com/heroku/heroku-buildpack-nodejs.git
+
+- name: buildpacks:clear hello-world
+  dokku_buildpacks:
+    app: hello-world
+    buildpacks: []
+```
+
 ### dokku_certs
 
 Manages ssl configuration for an app.

--- a/library/dokku_buildpacks.py
+++ b/library/dokku_buildpacks.py
@@ -1,0 +1,120 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.dokku_utils import subprocess_check_output
+from shlex import quote as shell_escape
+from typing import TypedDict
+
+DOCUMENTATION = """
+---
+module: dokku_buildpacks
+short_description: Manage buildpack settings for a given dokku application
+options:
+  app:
+    description:
+      - The name of the app
+    required: True
+    default: null
+    aliases: []
+  buildpacks:
+    description:
+      - A list of buildpacks to set on the app
+    required: True
+    default: null
+    aliases: []
+author: Andrew Kvalheim
+requirements: [ ]
+"""
+
+EXAMPLES = """
+- name: buildpacks:add hello-world […], buildpacks:add hello-world […]
+  dokku_buildpacks:
+    app: hello-world
+    buildpacks:
+      - https://github.com/heroku/heroku-buildpack-ruby.git
+      - https://github.com/heroku/heroku-buildpack-nodejs.git
+
+- name: buildpacks:clear hello-world
+  dokku_buildpacks:
+    app: hello-world
+    buildpacks: []
+"""
+
+Diff = TypedDict("Diff", {"before": str, "after": str})
+Params = TypedDict("Params", {"app": str, "buildpacks": list[str]})
+
+
+def dokku_buildpacks(
+    params: Params, check_mode: bool
+) -> tuple[str, None] | tuple[None, None | Diff]:
+    app, expected = params["app"], params["buildpacks"]
+
+    error, actual = dokku_buildpacks_list(app)
+    if error is not None:
+        return error, None
+
+    if actual == expected:
+        return None, None
+
+    # OPTIMIZE: Instead of clearing and reconstructing the entire list, use
+    # indexed add/set/remove to only change entries as necessary.
+    if actual:
+        if not check_mode:
+            error = dokku_buildpacks_clear(app)
+            if error is not None:
+                return error, None
+    for buildpack in expected:
+        if not check_mode:
+            error = dokku_buildpacks_add(app, buildpack)
+            if error is not None:
+                return error, None
+
+    return None, {"before": "\n".join(actual), "after": "\n".join(expected)}
+
+
+def dokku_buildpacks_add(app: str, buildpack: str) -> None | str:
+    command = "dokku --quiet buildpacks:add {} {}".format(
+        shell_escape(app), shell_escape(buildpack)
+    )
+
+    _, error = subprocess_check_output(command)
+
+    return error
+
+
+def dokku_buildpacks_clear(app: str) -> None | str:
+    command = "dokku --quiet buildpacks:clear {}".format(shell_escape(app))
+
+    _, error = subprocess_check_output(command)
+
+    return error
+
+
+def dokku_buildpacks_list(app: str) -> tuple[str, None] | tuple[None, list[str]]:
+    command = "dokku --quiet buildpacks:list {}".format(shell_escape(app))
+
+    lines, error = subprocess_check_output(command)
+    if error is not None:
+        return error, None
+
+    buildpacks = lines
+
+    return None, buildpacks
+
+
+def main():
+    argument_spec = {
+        "app": {"required": True, "type": "str"},
+        "buildpacks": {"required": True, "type": "list"},
+    }
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    error, diff = dokku_buildpacks(module.params, module.check_mode)
+    if error is not None:
+        module.fail_json(error)
+
+    module.exit_json(changed=diff is not None, diff=diff)
+
+
+if __name__ == "__main__":
+    main()

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -308,6 +308,82 @@
         build-dir '/app' not found in output of 'dokku builder':
         {{ dokku_builder.stdout }}
 
+  # Testing dokku_buildpacks
+  - name: Set buildpacks
+    dokku_buildpacks:
+      app: example-app
+      buildpacks:
+      - https://github.com/heroku/heroku-buildpack-ruby.git
+      - https://github.com/heroku/heroku-buildpack-nodejs.git
+    register: dokku_buildpacks_set_changed
+    diff: true
+
+  - name: Expect that setting buildpacks is registered as a change
+    assert:
+      that:
+      - dokku_buildpacks_set_changed.changed
+      msg: |
+        Setting buildpacks didn't register as a change
+
+  - name: List buildpacks
+    command: dokku --quiet buildpacks:list example-app
+    register: dokku_buildpacks_list
+    changed_when: false
+
+  - name: Expect set buildpacks
+    assert:
+      that:
+      - dokku_buildpacks_list.stdout_lines | map('trim') | list == [
+          "https://github.com/heroku/heroku-buildpack-ruby.git",
+          "https://github.com/heroku/heroku-buildpack-nodejs.git"
+        ]
+      msg: |-
+        Expected buildpacks not found in output of 'dokku buildpacks:list':
+        {{ dokku_buildpacks_list.stdout }}
+
+  - name: Set the same buildpacks
+    dokku_buildpacks:
+      app: example-app
+      buildpacks:
+      - https://github.com/heroku/heroku-buildpack-ruby.git
+      - https://github.com/heroku/heroku-buildpack-nodejs.git
+    register: dokku_buildpacks_set_unchanged
+    diff: true
+
+  - name: Expect that setting the same buildpacks is not registered as a change
+    assert:
+      that:
+      - not dokku_buildpacks_set_unchanged.changed
+      msg: |
+        Setting the same buildpacks registered as a change
+
+  - name: Clear buildpacks
+    dokku_buildpacks:
+      app: example-app
+      buildpacks: []
+    register: dokku_buildpacks_clear
+    diff: true
+
+  - name: Expect that clearing buildpacks is registered as a change
+    assert:
+      that:
+      - dokku_buildpacks_clear.changed
+      msg: |
+        Clearing buildpacks didn't register as a change
+
+  - name: List buildpacks
+    command: dokku --quiet buildpacks:list example-app
+    register: dokku_buildpacks_list
+    changed_when: false
+
+  - name: Expect cleared buildpacks
+    assert:
+      that:
+      - dokku_buildpacks_list.stdout_lines | map('trim') | list == []
+      msg: |-
+        Expected clearing not found in output of 'dokku buildpacks:list':
+        {{ dokku_buildpacks_list.stdout }}
+
   # Testing dokku_http_auth
   - name: Enabling http-auth for an app
     dokku_http_auth:


### PR DESCRIPTION
I didn’t see a convenient way to [configure buildpacks](https://dokku.com/docs/deployment/builders/herokuish-buildpacks/) via Ansible. This adds a `dokku_buildpacks` library, though I’m not very familiar with Ansible, Python, or buildpacks, so it would likely benefit from some critical review.