### PR TITLE
Fix Ansible 2.17+ compatibility issues

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,7 +5,7 @@
   pre_tasks:
   - name: Update apt cache.
     apt: update_cache=yes cache_valid_time=600
-    when: ansible_os_family == 'Debian'
+    when: ansible_facts["os_family"] == 'Debian'
 
   roles:
   - role: dokku_bot.ansible_dokku  # noqa

--- a/tasks/install-pin.yml
+++ b/tasks/install-pin.yml
@@ -1,10 +1,10 @@
-- name: remove pin from {{ item.key }} package
+- name: remove pin from package
   file:
     path: /etc/apt/preferences.d/ansible-hold-{{ item.key }}
     state: absent
-  when: not item.value
+  when: item.value | default('') == ''
 
-- name: pin {{ item.key }} package
+- name: pin package
   copy:
     dest: /etc/apt/preferences.d/ansible-hold-{{ item.key }}
     content: |
@@ -12,4 +12,4 @@
       Pin: version {{ item.value }}
       Pin-Priority: 1001
     mode: 0644
-  when: item.value
+  when: item.value | default('') != ''

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -10,7 +10,7 @@
 - name: dokku repo
   apt_repository:
     filename: dokku
-    repo: 'deb https://packagecloud.io/dokku/dokku/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main'
+    repo: 'deb https://packagecloud.io/dokku/dokku/{{ ansible_facts["distribution"] | lower }} {{ ansible_facts["distribution_release"] }} main'
     state: present
   tags:
   - dokku
@@ -77,7 +77,7 @@
 # does *not* check whether the package version agrees with the pinned version.
 # Cannot be done in the pinning loop since all packages need to be unpinned
 # (or you can get version conflicts).
-- name: install pinned {{ item.key }} package
+- name: install pinned package
   apt:
     name: "{{ item.key }}={{ item.value }}"
   with_dict:
@@ -85,7 +85,7 @@
     sshcommand: "{{ sshcommand_version }}"
     herokuish: "{{ herokuish_version }}"
     dokku: "{{ dokku_version }}"
-  when: item.value
+  when: item.value | default('') != ''
 
 - name: install dokku packages
   apt:

--- a/tasks/ssh-keys.yml
+++ b/tasks/ssh-keys.yml
@@ -7,7 +7,7 @@
   - dokku-ssh-keys
   ignore_errors: true
 
-- name: add ssh key for user {{ item.username }}
+- name: add ssh key for user
   include_tasks: ssh-key.yml
   tags:
   - dokku


### PR DESCRIPTION
## Summary

This PR fixes compatibility issues with Ansible 2.17+ which enforces stricter boolean conditionals and deprecates auto-injected facts variables.

## Changes

### 1. Fix boolean conditional errors

Ansible 2.17+ requires boolean results for `when:` conditionals. Empty strings are no longer implicitly falsy.

**Error encountered:**
```
Conditional result (False) was derived from value of type 'str'.
Conditionals must have a boolean result.
```

**Fix:** Change `when: item.value` → `when: item.value | default('') != ''`

Files changed:
- `tasks/install-pin.yml` (lines 5, 15)
- `tasks/install.yml` (line 88)

### 2. Fix INJECT_FACTS_AS_VARS deprecation

**Warning encountered:**
```
INJECT_FACTS_AS_VARS default to `True` is deprecated.
Use `ansible_facts["fact_name"]` instead.
This feature will be removed from ansible-core version 2.24.
```

**Fix:** Change `ansible_distribution` → `ansible_facts["distribution"]`

Files changed:
- `tasks/install.yml` (line 13)
- `molecule/default/converge.yml` (line 8)

### 3. Remove loop variables from task names

Task names are evaluated before loops run, causing template warnings when using `{{ item.* }}`.

**Warning encountered:**
```
Encountered 1 template error: 'item' is undefined
```

**Fix:** Remove `{{ item.key }}` and `{{ item.username }}` from task names

Files changed:
- `tasks/install-pin.yml` (lines 1, 7)
- `tasks/install.yml` (line 80)
- `tasks/ssh-keys.yml` (line 10)

## Testing

**Environment:**
- Ansible 2.20.1
- Ubuntu 24.04 target
- Dokku latest

**Linting:**
- `yamllint tasks/` ✓ (only pre-existing warnings)
- `ansible-lint tasks/` ✓

**Note:** Molecule tests fail due to a pre-existing test infrastructure issue (Docker container missing Python symlink), unrelated to these changes.