### PR TITLE
install: replace deprecated apt_repository with templated sources file

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,11 +7,28 @@
   tags:
   - dokku
 
+# apt_repository is deprecated (removal in ansible-core 2.25) and its
+# suggested replacement, deb822_repository, requires ansible-core 2.15+,
+# which would break this role's min_ansible_version. Writing the sources
+# file directly avoids both the deprecation and the version bump.
 - name: dokku repo
-  apt_repository:
-    filename: dokku
-    repo: 'deb https://packagecloud.io/dokku/dokku/{{ ansible_facts["distribution"] | lower }} {{ ansible_facts["distribution_release"] }} main'
-    state: present
+  copy:
+    dest: /etc/apt/sources.list.d/dokku.list
+    content: |
+      deb https://packagecloud.io/dokku/dokku/{{ ansible_facts["distribution"] | lower }} {{ ansible_facts["distribution_release"] }} main
+    mode: '0644'
+  register: dokku_repo
+  tags:
+  - dokku
+
+# apt_repository refreshed the cache by default (update_cache: yes); do the
+# same here so the package install tasks below see the new repo. This can't
+# be a handler: the cache must be refreshed before the install tasks run,
+# whereas handlers only fire at the end of the play.
+- name: update apt cache for dokku repo  # noqa: no-handler
+  apt:
+    update_cache: true
+  when: dokku_repo is changed
   tags:
   - dokku
 


### PR DESCRIPTION
## Problem

`apt_repository` is deprecated and scheduled for removal in ansible-core 2.25. The role emits this warning on every run:

```
[DEPRECATION WARNING]: apt_repository has been deprecated. Use deb822_repository instead.
Origin: .../tasks/install.yml:11
```

## Why not `deb822_repository`?

The suggested replacement was only added in **ansible-core 2.15** and requires a `python3-debian` dependency on the target, so adopting it would raise the role's effective minimum ansible version (`min_ansible_version` is currently `'2.2'`).

## Approach

The deprecation is about the *module*, not the repository or the sources-file format — so this PR writes the sources file directly with `copy`, which:

- works on **every** ansible-core version, with no new dependencies, and
- produces the same `/etc/apt/sources.list.d/dokku.list` as before.

`apt_repository` refreshed the apt cache by default (`update_cache: yes`), so a change-gated `apt: update_cache` task is added immediately after to preserve that behaviour before the package-install tasks run. It deliberately isn't a handler — handlers fire at the end of the play, but the cache must be fresh before the very next install tasks (hence the documented `# noqa: no-handler`).

## Validation

- `yamllint -c .yamllint tasks/install.yml` — passes
- `ansible-lint tasks/install.yml` (v25.9.2) — passes (profile: production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
